### PR TITLE
fix: resolve legacy test API issue and add Bearer prefix to token

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -17,12 +17,13 @@ export class MixSpaceAPI {
   }
 
   private getHeaders(hasBody: boolean) {
+    const raw = (this.profile.token || '').trim()
+    const token = raw.toLowerCase().startsWith('bearer ') ? raw : `Bearer ${raw}`
+
     const headers: Record<string, string> = {
-      Authorization: this.profile.token,
+      Authorization: token,
     }
-    if (hasBody) {
-      headers['Content-Type'] = 'application/json'
-    }
+    if (hasBody) headers['Content-Type'] = 'application/json'
     return headers
   }
 
@@ -176,7 +177,7 @@ export class MixSpaceAPI {
   // ===== Connection Test =====
 
   async testConnection(): Promise<{ ok: boolean; isGuest?: boolean; debug?: string }> {
-    const testUrl = `${this.baseUrl}/master/check_logged`
+    const testUrl = `${this.baseUrl}/owner/check_logged`
 
     try {
       console.log('[MixSpace] Testing connection to:', testUrl)


### PR DESCRIPTION
### Description

1. 旧的测试接口 404

2. 在使用中没有看到有是否带 Bearer 的标识，填 token 的时候有些疑惑
<img width="1412" height="132" alt="CleanShot 2026-02-24 at 18 21 28@2x" src="https://github.com/user-attachments/assets/b9be6882-ee64-4207-a84f-f11d7d5b2904" />