### PR TITLE
feat: support Mix Space v3 (v13+) while keeping v2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ pnpm run build
 
 每个 Profile 包含以下设置：
 
-| 设置         | 说明                         | 示例                         |
-| ------------ | ---------------------------- | ---------------------------- |
-| Profile Name | 配置名称                     | `Production` / `Development` |
-| API Endpoint | Mix Space API 地址           | `https://your-domain.com/api/v3` |
-| API Token    | 认证 Token（后台 设定→账号与安全→API Token，作为 x-api-key 头发送）               |                              |
-| Site URL     | 网站地址（用于反向链接转换） | `https://example.com`        |
+| 设置         | 说明                                                                | 示例                             |
+| ------------ | ------------------------------------------------------------------- | -------------------------------- |
+| Profile Name | 配置名称                                                            | `Production` / `Development`     |
+| API Endpoint | Mix Space API 地址                                                  | `https://your-domain.com/api/v3` |
+| API Token    | 认证 Token（后台 设定→账号与安全→API Token，作为 x-api-key 头发送） |                                  |
+| Site URL     | 网站地址（用于反向链接转换）                                        | `https://example.com`            |
 
 ### AI 设置
 

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ pnpm run build
 | 设置         | 说明                         | 示例                         |
 | ------------ | ---------------------------- | ---------------------------- |
 | Profile Name | 配置名称                     | `Production` / `Development` |
-| API Endpoint | Mix Space API 地址           | `https://api.example.com/v2` |
-| Bearer Token | API 认证 Token               |                              |
+| API Endpoint | Mix Space API 地址           | `https://your-domain.com/api/v3` |
+| API Token    | 认证 Token（后台 设定→账号与安全→API Token，作为 x-api-key 头发送）               |                              |
 | Site URL     | 网站地址（用于反向链接转换） | `https://example.com`        |
 
 ### AI 设置

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -51,11 +51,12 @@ describe('MixSpaceAPI', () => {
         id: 'note123',
         nid: 42,
         title: 'Test Note',
-        created: '2024-01-01',
-        modified: null,
+        created_at: '2024-01-01',
+        modified_at: null,
       }
 
-      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, responseData))
+      // v3 wraps the resource in a { data } envelope; request() unwraps it.
+      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, { data: responseData }))
 
       const result = await api.createNote(notePayload)
 
@@ -138,10 +139,11 @@ describe('MixSpaceAPI', () => {
         id: 'post123',
         title: 'Test Post',
         slug: 'test-post',
-        categoryId: 'cat123',
+        category_id: 'cat123',
       }
 
-      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, responseData))
+      // v3 wraps the resource in a { data } envelope; request() unwraps it.
+      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, { data: responseData }))
 
       const result = await api.createPost(postPayload)
 
@@ -404,6 +406,165 @@ describe('MixSpaceAPI', () => {
 
       expect(result.ok).toBe(false)
       expect(result.debug).toContain('SSL/Certificate error')
+    })
+  })
+
+  describe('v2 compatibility', () => {
+    const v2Profile: MixSpaceProfile = { ...testProfile, apiVersion: 'v2' }
+    let v2api: MixSpaceAPI
+
+    beforeEach(() => {
+      v2api = new MixSpaceAPI(v2Profile)
+    })
+
+    it('should send the Authorization header (not x-api-key)', async () => {
+      vi.mocked(requestUrl).mockResolvedValue(
+        mockResponse(200, {
+          id: 'note123',
+          nid: 1,
+          title: 'T',
+          created: '2024-01-01',
+          modified: null,
+        }),
+      )
+
+      await v2api.createNote({ title: 'T', text: 'C' })
+
+      expect(requestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: {
+            Authorization: 'test-token',
+            'Content-Type': 'application/json',
+          },
+        }),
+      )
+    })
+
+    it('should not unwrap a bare response and should normalize note fields', async () => {
+      vi.mocked(requestUrl).mockResolvedValue(
+        mockResponse(200, {
+          id: 'note123',
+          nid: 42,
+          title: 'Test Note',
+          created: '2024-01-01',
+          modified: null,
+          topicId: 't1',
+        }),
+      )
+
+      const result = await v2api.createNote({ title: 'Test Note', text: 'C' })
+
+      expect(result).toEqual({
+        id: 'note123',
+        nid: 42,
+        title: 'Test Note',
+        created_at: '2024-01-01',
+        modified_at: null,
+        mood: undefined,
+        weather: undefined,
+        topic_id: 't1',
+      })
+    })
+
+    it('should normalize post camelCase fields to snake_case', async () => {
+      vi.mocked(requestUrl).mockResolvedValue(
+        mockResponse(200, {
+          id: 'post123',
+          title: 'Test Post',
+          slug: 'test-post',
+          created: '2024-01-01',
+          modified: null,
+          categoryId: 'c1',
+          category: { id: 'c1', name: 'Tech', slug: 'tech' },
+        }),
+      )
+
+      const result = await v2api.createPost({
+        title: 'Test Post',
+        text: 'C',
+        slug: 'test-post',
+        categoryId: 'c1',
+      })
+
+      expect(result).toEqual({
+        id: 'post123',
+        title: 'Test Post',
+        slug: 'test-post',
+        created_at: '2024-01-01',
+        modified_at: null,
+        category_id: 'c1',
+        category: { id: 'c1', name: 'Tech', slug: 'tech' },
+      })
+    })
+
+    it('should read the v2 { message } error shape', async () => {
+      vi.mocked(requestUrl).mockResolvedValue(mockResponse(400, { message: 'bad' }))
+
+      await expect(v2api.createNote({ title: 'T', text: 'C' })).rejects.toThrow('bad')
+    })
+
+    it('should unwrap the v2 { data } envelope for categories', async () => {
+      // v2 list endpoints still wrap results in { data }, even though v2 single
+      // resources are bare. getCategories must unwrap it so callers get an array.
+      const categories = [{ id: 'c1', name: 'Tech', slug: 'tech' }]
+      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, { data: categories }))
+
+      const result = await v2api.getCategories()
+
+      expect(result).toEqual(categories)
+    })
+
+    it('should unwrap the v2 { data } envelope for topics', async () => {
+      const topics = [{ id: 't1', name: 'My Topic', slug: 'my-topic' }]
+      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, { data: topics }))
+
+      const result = await v2api.getTopics()
+
+      expect(result).toEqual(topics)
+    })
+
+    it('should resolve a v2 category by name through the { data } envelope', async () => {
+      // Guards the downstream .find() path that crashed when getCategories
+      // returned the raw envelope object instead of an array.
+      const categories = [{ id: 'c1', name: 'Technology', slug: 'tech' }]
+      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, { data: categories }))
+
+      const result = await v2api.getCategoryByNameOrSlug('Technology')
+
+      expect(result).toEqual({ id: 'c1', name: 'Technology', slug: 'tech' })
+    })
+
+    it('should test connection against /master/check_logged with the Authorization header', async () => {
+      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, { ok: 1, isGuest: false }))
+
+      const result = await v2api.testConnection()
+
+      expect(result.ok).toBe(true)
+      expect(requestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://api.example.com/master/check_logged',
+          method: 'GET',
+          headers: { Authorization: 'test-token' },
+        }),
+      )
+    })
+
+    it('should report guest when isGuest is true', async () => {
+      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, { ok: 1, isGuest: true }))
+
+      const result = await v2api.testConnection()
+
+      expect(result.ok).toBe(false)
+      expect(result.isGuest).toBe(true)
+    })
+
+    it('should report guest on 401', async () => {
+      vi.mocked(requestUrl).mockResolvedValue(mockResponse(401, null))
+
+      const result = await v2api.testConnection()
+
+      expect(result.ok).toBe(false)
+      expect(result.isGuest).toBe(true)
     })
   })
 

--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -65,7 +65,7 @@ describe('MixSpaceAPI', () => {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            Authorization: 'test-token',
+            'x-api-key': 'test-token',
           },
           body: JSON.stringify(notePayload),
         }),
@@ -325,31 +325,49 @@ describe('MixSpaceAPI', () => {
   })
 
   describe('testConnection', () => {
-    it('should return ok when connection is successful', async () => {
-      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, { ok: 1, isGuest: false }))
+    it('should return ok when authenticated (2xx from owner-only endpoint)', async () => {
+      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, { data: [] }))
 
       const result = await api.testConnection()
 
       expect(result.ok).toBe(true)
-      expect(result.isGuest).toBe(false)
     })
 
-    it('should return not ok when user is guest', async () => {
-      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, { ok: 1, isGuest: true }))
+    it('should call the owner-only /snippets endpoint with the x-api-key header', async () => {
+      vi.mocked(requestUrl).mockResolvedValue(mockResponse(200, { data: [] }))
+
+      await api.testConnection()
+
+      expect(requestUrl).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://api.example.com/snippets',
+          method: 'GET',
+          headers: { 'x-api-key': 'test-token' },
+        }),
+      )
+    })
+
+    it('should return not ok and isGuest on 401 (invalid token)', async () => {
+      vi.mocked(requestUrl).mockResolvedValue(
+        mockResponse(401, { error: { message: 'Invalid token' } }),
+      )
 
       const result = await api.testConnection()
 
       expect(result.ok).toBe(false)
       expect(result.isGuest).toBe(true)
+      expect(result.debug).toContain('Auth failed')
     })
 
-    it('should return not ok on HTTP error', async () => {
-      vi.mocked(requestUrl).mockResolvedValue(mockResponse(401, { message: 'Unauthorized' }))
+    it('should return not ok on other HTTP errors', async () => {
+      vi.mocked(requestUrl).mockResolvedValue(
+        mockResponse(500, { error: { message: 'Server error' } }),
+      )
 
       const result = await api.testConnection()
 
       expect(result.ok).toBe(false)
-      expect(result.debug).toContain('HTTP 401')
+      expect(result.debug).toContain('HTTP 500')
     })
 
     it('should handle network errors', async () => {

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,5 @@
 import { requestUrl } from 'obsidian'
+import { resolveApiVersion, type ApiVersion } from './types'
 import type {
   MixSpaceProfile,
   NotePayload,
@@ -9,19 +10,52 @@ import type {
   Topic,
 } from './types'
 
+// v2 raw response shapes (camelCase, bare). Normalized into the v3 snake_case
+// NoteResponse / PostResponse before being returned to callers.
+interface V2NoteRaw {
+  id: string
+  nid: number
+  title: string
+  created?: string
+  modified?: string | null
+  mood?: string
+  weather?: string
+  topicId?: string
+}
+
+interface V2PostRaw {
+  id: string
+  title: string
+  slug: string
+  created?: string
+  modified?: string | null
+  categoryId?: string
+  category?: Category
+}
+
 export class MixSpaceAPI {
-  constructor(private profile: MixSpaceProfile) {}
+  private apiVersion: ApiVersion
+
+  constructor(private profile: MixSpaceProfile) {
+    this.apiVersion = resolveApiVersion(profile)
+  }
 
   updateProfile(profile: MixSpaceProfile) {
     this.profile = profile
+    this.apiVersion = resolveApiVersion(profile)
+  }
+
+  private get isV2() {
+    return this.apiVersion === 'v2'
   }
 
   private getHeaders(hasBody: boolean) {
-    const headers: Record<string, string> = {
-      // Mix Space v13 authenticates API tokens via the `x-api-key` header
-      // (the `Authorization` header is reserved for better-auth session cookies).
-      'x-api-key': this.profile.token,
-    }
+    const headers: Record<string, string> = this.isV2
+      ? // Mix Space v2 authenticates API tokens via the bare `Authorization` header.
+        { Authorization: this.profile.token }
+      : // Mix Space v13 (v3) authenticates API tokens via the `x-api-key` header
+        // (the `Authorization` header is reserved for better-auth session cookies).
+        { 'x-api-key': this.profile.token }
     if (hasBody) {
       headers['Content-Type'] = 'application/json'
     }
@@ -67,20 +101,22 @@ export class MixSpaceAPI {
       })
 
       if (response.status >= 400) {
-        // Mix Space v13 error shape: { error: { code, message } }.
-        // Fall back to the legacy `message` field and raw text.
+        // v3 error shape: { error: { code, message } }. v2 error shape: { message }.
+        // Prefer the version-native field, fall back to the other, then raw text.
         const j = json as { error?: { message?: string }; message?: string } | null
-        const errorMsg =
-          j?.error?.message || j?.message || response.text || `HTTP ${response.status}`
+        const errorMsg = this.isV2
+          ? j?.message || j?.error?.message || response.text || `HTTP ${response.status}`
+          : j?.error?.message || j?.message || response.text || `HTTP ${response.status}`
         throw new Error(String(errorMsg))
       }
 
-      // Mix Space v13 wraps successful responses as { data, meta }.
-      // Unwrap `data` so callers receive the resource directly (v2 returned it bare).
-      if (json && typeof json === 'object' && 'data' in json) {
-        return (json as { data: T }).data
+      // v3 wraps successful responses as { data, meta }; unwrap `data` so callers
+      // receive the resource directly. v2 returns the resource bare, so skip unwrapping.
+      let data: unknown = json
+      if (!this.isV2 && json && typeof json === 'object' && 'data' in json) {
+        data = (json as { data: unknown }).data
       }
-      return json as T
+      return data as T
     } catch (error) {
       // Log full error details including any response data
       const err = error as Record<string, unknown>
@@ -94,18 +130,55 @@ export class MixSpaceAPI {
     }
   }
 
+  // ===== Normalization (v2 camelCase -> v3 snake_case) =====
+
+  private normalizeNote(raw: NoteResponse | V2NoteRaw): NoteResponse {
+    if (!this.isV2) return raw as NoteResponse
+    const r = raw as V2NoteRaw
+    return {
+      id: r.id,
+      nid: r.nid,
+      title: r.title,
+      created_at: r.created as string,
+      modified_at: r.modified ?? null,
+      mood: r.mood,
+      weather: r.weather,
+      topic_id: r.topicId,
+    }
+  }
+
+  private normalizePost(raw: PostResponse | V2PostRaw): PostResponse {
+    if (!this.isV2) return raw as PostResponse
+    const r = raw as V2PostRaw
+    return {
+      id: r.id,
+      title: r.title,
+      slug: r.slug,
+      created_at: r.created as string,
+      modified_at: r.modified ?? null,
+      category_id: r.categoryId as string,
+      category: r.category as Category,
+    }
+  }
+
   // ===== Note API =====
 
   async createNote(payload: NotePayload): Promise<NoteResponse> {
-    return this.request('/notes', 'POST', payload)
+    return this.normalizeNote(
+      await this.request<NoteResponse | V2NoteRaw>('/notes', 'POST', payload),
+    )
   }
 
   async updateNote(id: string, payload: Partial<NotePayload>): Promise<NoteResponse> {
-    return this.request(`/notes/${id}`, 'PUT', payload)
+    return this.normalizeNote(
+      await this.request<NoteResponse | V2NoteRaw>(`/notes/${id}`, 'PUT', payload),
+    )
   }
 
   async patchNote(id: string, payload: Partial<NotePayload>): Promise<NoteResponse> {
-    return this.request(`/notes/${id}`, 'PATCH', payload)
+    return this.normalizeNote(
+      await this.request<NoteResponse | V2NoteRaw>(`/notes/${id}`, 'PATCH', payload),
+    )
   }
 
   async deleteNote(nid: string): Promise<void> {
@@ -115,15 +188,21 @@ export class MixSpaceAPI {
   // ===== Post API =====
 
   async createPost(payload: PostPayload): Promise<PostResponse> {
-    return this.request('/posts', 'POST', payload)
+    return this.normalizePost(
+      await this.request<PostResponse | V2PostRaw>('/posts', 'POST', payload),
+    )
   }
 
   async updatePost(id: string, payload: Partial<PostPayload>): Promise<PostResponse> {
-    return this.request(`/posts/${id}`, 'PUT', payload)
+    return this.normalizePost(
+      await this.request<PostResponse | V2PostRaw>(`/posts/${id}`, 'PUT', payload),
+    )
   }
 
   async patchPost(id: string, payload: Partial<PostPayload>): Promise<PostResponse> {
-    return this.request(`/posts/${id}`, 'PATCH', payload)
+    return this.normalizePost(
+      await this.request<PostResponse | V2PostRaw>(`/posts/${id}`, 'PATCH', payload),
+    )
   }
 
   async deletePost(id: string): Promise<void> {
@@ -134,9 +213,11 @@ export class MixSpaceAPI {
 
   async getCategories(): Promise<Category[]> {
     try {
-      // request() already unwraps the v13 `{ data }` envelope.
-      const categories = await this.request<Category[]>('/categories', 'GET')
-      return categories || []
+      // v3: request() already unwrapped the `{ data }` envelope into an array.
+      // v2: list endpoints still return a `{ data }` envelope (request() leaves
+      // v2 responses untouched, since v2 single resources are bare), so unwrap here.
+      const res = await this.request<Category[] | { data?: Category[] }>('/categories', 'GET')
+      return Array.isArray(res) ? res : (res?.data ?? [])
     } catch {
       return []
     }
@@ -144,8 +225,9 @@ export class MixSpaceAPI {
 
   async getTopics(): Promise<Topic[]> {
     try {
-      const topics = await this.request<Topic[]>('/topics', 'GET')
-      return topics || []
+      // See getCategories(): v2 list endpoints wrap results in `{ data }`.
+      const res = await this.request<Topic[] | { data?: Topic[] }>('/topics', 'GET')
+      return Array.isArray(res) ? res : (res?.data ?? [])
     } catch {
       return []
     }
@@ -186,7 +268,35 @@ export class MixSpaceAPI {
 
   // ===== Connection Test =====
 
-  async testConnection(): Promise<{ ok: boolean; isGuest?: boolean; debug?: string }> {
+  public async testConnection(): Promise<{ ok: boolean; isGuest?: boolean; debug?: string }> {
+    return this.isV2 ? this.testConnectionV2() : this.testConnectionV3()
+  }
+
+  // Classify a thrown network error into a human-readable debug string. Shared by both versions.
+  private classifyNetworkError(e: unknown, testUrl: string): string {
+    let debug: string
+    if (e instanceof Error) {
+      if (e.message.includes('ENOTFOUND') || e.message.includes('getaddrinfo')) {
+        debug = `DNS lookup failed - host not found (URL: ${testUrl})`
+      } else if (e.message.includes('ECONNREFUSED')) {
+        debug = `Connection refused - server may be down (URL: ${testUrl})`
+      } else if (e.message.includes('ETIMEDOUT') || e.message.includes('timeout')) {
+        debug = `Connection timeout - server not responding (URL: ${testUrl})`
+      } else if (e.message.includes('CERT') || e.message.includes('SSL')) {
+        debug = `SSL/Certificate error: ${e.message} (URL: ${testUrl})`
+      } else if (e.message.includes('net::ERR_')) {
+        debug = `Network error: ${e.message} (URL: ${testUrl})`
+      } else {
+        debug = `${e.message} (URL: ${testUrl})`
+      }
+    } else {
+      debug = `Unknown error: ${String(e)} (URL: ${testUrl})`
+    }
+    console.error('[MixSpace] Connection test failed:', debug)
+    return debug
+  }
+
+  private async testConnectionV3(): Promise<{ ok: boolean; isGuest?: boolean; debug?: string }> {
     // v13 removed /master/check_logged. Use an owner-only GET endpoint instead:
     // /snippets returns 200 with a valid owner token, 401 with an invalid one.
     const testUrl = `${this.baseUrl}/snippets`
@@ -231,30 +341,50 @@ export class MixSpaceAPI {
       // 2xx: reachable AND authenticated as owner
       return { ok: true, debug: `HTTP ${response.status} (URL: ${testUrl})` }
     } catch (e) {
-      // Parse different error types for better debugging
-      let debug: string
+      return { ok: false, debug: this.classifyNetworkError(e, testUrl) }
+    }
+  }
 
-      if (e instanceof Error) {
-        // Check for common network error patterns
-        if (e.message.includes('ENOTFOUND') || e.message.includes('getaddrinfo')) {
-          debug = `DNS lookup failed - host not found (URL: ${testUrl})`
-        } else if (e.message.includes('ECONNREFUSED')) {
-          debug = `Connection refused - server may be down (URL: ${testUrl})`
-        } else if (e.message.includes('ETIMEDOUT') || e.message.includes('timeout')) {
-          debug = `Connection timeout - server not responding (URL: ${testUrl})`
-        } else if (e.message.includes('CERT') || e.message.includes('SSL')) {
-          debug = `SSL/Certificate error: ${e.message} (URL: ${testUrl})`
-        } else if (e.message.includes('net::ERR_')) {
-          debug = `Network error: ${e.message} (URL: ${testUrl})`
-        } else {
-          debug = `${e.message} (URL: ${testUrl})`
-        }
-      } else {
-        debug = `Unknown error: ${String(e)} (URL: ${testUrl})`
+  private async testConnectionV2(): Promise<{ ok: boolean; isGuest?: boolean; debug?: string }> {
+    // v2 exposes /master/check_logged returning { ok: 1, isGuest }.
+    const testUrl = `${this.baseUrl}/master/check_logged`
+
+    try {
+      console.log('[MixSpace] Testing connection to:', testUrl)
+
+      const response = await requestUrl({
+        url: testUrl,
+        method: 'GET',
+        headers: this.getHeaders(false),
+        throw: false, // inspect status ourselves
+      })
+
+      console.log('[MixSpace] Connection response:', {
+        status: response.status,
+        body: response.text,
+      })
+
+      if (response.status === 401 || response.status === 403) {
+        return { ok: false, isGuest: true, debug: `Auth failed (URL: ${testUrl})` }
+      }
+      if (response.status >= 400) {
+        return { ok: false, debug: `HTTP ${response.status} (URL: ${testUrl})` }
       }
 
-      console.error('[MixSpace] Connection test failed:', debug)
-      return { ok: false, debug }
+      let body: { isGuest?: boolean } | null = null
+      try {
+        body = response.json as { isGuest?: boolean }
+      } catch {
+        // empty / non-JSON body
+      }
+
+      // v2 returns { ok: 1, isGuest }: owner is authenticated iff isGuest === false.
+      if (body && body.isGuest === false) {
+        return { ok: true, debug: `HTTP ${response.status} owner (URL: ${testUrl})` }
+      }
+      return { ok: false, isGuest: true, debug: `Guest/invalid token (URL: ${testUrl})` }
+    } catch (e) {
+      return { ok: false, debug: this.classifyNetworkError(e, testUrl) }
     }
   }
 }

--- a/src/api.ts
+++ b/src/api.ts
@@ -18,7 +18,9 @@ export class MixSpaceAPI {
 
   private getHeaders(hasBody: boolean) {
     const headers: Record<string, string> = {
-      Authorization: this.profile.token,
+      // Mix Space v13 authenticates API tokens via the `x-api-key` header
+      // (the `Authorization` header is reserved for better-auth session cookies).
+      'x-api-key': this.profile.token,
     }
     if (hasBody) {
       headers['Content-Type'] = 'application/json'
@@ -51,7 +53,7 @@ export class MixSpaceAPI {
       })
 
       // Handle empty response body (common for DELETE requests)
-      let json: T | null = null
+      let json: unknown = null
       try {
         json = response.json
       } catch {
@@ -65,11 +67,19 @@ export class MixSpaceAPI {
       })
 
       if (response.status >= 400) {
+        // Mix Space v13 error shape: { error: { code, message } }.
+        // Fall back to the legacy `message` field and raw text.
+        const j = json as { error?: { message?: string }; message?: string } | null
         const errorMsg =
-          (json as Record<string, unknown>)?.message || response.text || `HTTP ${response.status}`
+          j?.error?.message || j?.message || response.text || `HTTP ${response.status}`
         throw new Error(String(errorMsg))
       }
 
+      // Mix Space v13 wraps successful responses as { data, meta }.
+      // Unwrap `data` so callers receive the resource directly (v2 returned it bare).
+      if (json && typeof json === 'object' && 'data' in json) {
+        return (json as { data: T }).data
+      }
       return json as T
     } catch (error) {
       // Log full error details including any response data
@@ -124,8 +134,9 @@ export class MixSpaceAPI {
 
   async getCategories(): Promise<Category[]> {
     try {
-      const response = await this.request<{ data: Category[] }>('/categories', 'GET')
-      return response.data || []
+      // request() already unwraps the v13 `{ data }` envelope.
+      const categories = await this.request<Category[]>('/categories', 'GET')
+      return categories || []
     } catch {
       return []
     }
@@ -133,8 +144,8 @@ export class MixSpaceAPI {
 
   async getTopics(): Promise<Topic[]> {
     try {
-      const response = await this.request<{ data: Topic[] }>('/topics', 'GET')
-      return response.data || []
+      const topics = await this.request<Topic[]>('/topics', 'GET')
+      return topics || []
     } catch {
       return []
     }
@@ -176,7 +187,9 @@ export class MixSpaceAPI {
   // ===== Connection Test =====
 
   async testConnection(): Promise<{ ok: boolean; isGuest?: boolean; debug?: string }> {
-    const testUrl = `${this.baseUrl}/master/check_logged`
+    // v13 removed /master/check_logged. Use an owner-only GET endpoint instead:
+    // /snippets returns 200 with a valid owner token, 401 with an invalid one.
+    const testUrl = `${this.baseUrl}/snippets`
 
     try {
       console.log('[MixSpace] Testing connection to:', testUrl)
@@ -185,30 +198,38 @@ export class MixSpaceAPI {
         url: testUrl,
         method: 'GET',
         headers: this.getHeaders(false),
+        throw: false, // inspect status ourselves
       })
 
       console.log('[MixSpace] Connection response:', {
         status: response.status,
-        body: response.json,
+        body: response.text,
       })
 
-      // Check for HTTP error status
-      if (response.status >= 400) {
-        const errorMsg = response.json?.message || response.text || `HTTP ${response.status}`
-        return {
-          ok: false,
-          debug: `HTTP ${response.status}: ${errorMsg} (URL: ${testUrl})`,
+      const parseErr = (): string => {
+        try {
+          return (
+            (response.json as { error?: { message?: string } })?.error?.message ||
+            response.text ||
+            `HTTP ${response.status}`
+          )
+        } catch {
+          return response.text || `HTTP ${response.status}`
         }
       }
 
-      const data = response.json as { ok: number; isGuest: boolean } | null
-      const ok = !!(data && data.ok === 1 && !data.isGuest)
-      const isGuest = !!(data && data.isGuest)
-      const debug = response.json
-        ? `Response: ${JSON.stringify(response.json)}`
-        : 'Empty response body'
+      // Reachable but token invalid / not the owner
+      if (response.status === 401 || response.status === 403) {
+        return { ok: false, isGuest: true, debug: `Auth failed: ${parseErr()} (URL: ${testUrl})` }
+      }
 
-      return { ok, isGuest, debug }
+      // Other non-2xx: endpoint / connection problem
+      if (response.status >= 400) {
+        return { ok: false, debug: `HTTP ${response.status}: ${parseErr()} (URL: ${testUrl})` }
+      }
+
+      // 2xx: reachable AND authenticated as owner
+      return { ok: true, debug: `HTTP ${response.status} (URL: ${testUrl})` }
     } catch (e) {
       // Parse different error types for better debugging
       let debug: string

--- a/src/main.ts
+++ b/src/main.ts
@@ -173,6 +173,9 @@ export default class MixSpacePlugin extends Plugin {
             apiEndpoint: data.apiEndpoint || '',
             token: data.token || '',
             siteUrl: data.siteUrl || '',
+            // Legacy flat users are overwhelmingly v2 backends; honor an
+            // explicit v3 marker if the old data recorded one.
+            apiVersion: data.apiVersion === 'v3' ? 'v3' : 'v2',
           },
         ],
         activeProfileId: 'default',

--- a/src/main.ts
+++ b/src/main.ts
@@ -473,7 +473,7 @@ export default class MixSpacePlugin extends Plugin {
         await this.updateFrontmatter(file, {
           oid: response.id,
           slug: response.slug,
-          categoryId: response.categoryId,
+          categoryId: response.category_id,
           updated: new Date().toISOString(),
           type: 'post',
         })

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -82,10 +82,10 @@ export class MixSpaceSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName('API Endpoint')
-      .setDesc('Your Mix Space API endpoint (e.g., https://api.innei.in/v2)')
+      .setDesc('Your Mix Space API endpoint, ending in /api/v3 (e.g., https://your-domain.com/api/v3)')
       .addText((text) =>
         text
-          .setPlaceholder('https://api.example.com/v2')
+          .setPlaceholder('https://your-domain.com/api/v3')
           .setValue(activeProfile.apiEndpoint)
           .onChange(async (value) => {
             activeProfile.apiEndpoint = value
@@ -95,8 +95,8 @@ export class MixSpaceSettingTab extends PluginSettingTab {
       )
 
     new Setting(containerEl)
-      .setName('Bearer Token')
-      .setDesc('Your Mix Space API token')
+      .setName('API Token')
+      .setDesc('Dashboard → 设定 → 账号与安全 → API Token (sent as the x-api-key header)')
       .addText((text) => {
         text
           .setPlaceholder('Enter your token')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_BASE_URLS,
   DEFAULT_PROFILE,
   getActiveProfile,
+  resolveApiVersion,
   type AIProvider,
   type MixSpaceProfile,
 } from './types'
@@ -80,12 +81,34 @@ export class MixSpaceSettingTab extends PluginSettingTab {
     // ===== API Settings =====
     containerEl.createEl('h3', { text: 'API Settings' })
 
+    const effectiveVersion = resolveApiVersion(activeProfile)
+
+    new Setting(containerEl)
+      .setName('API Version')
+      .setDesc(
+        'v3 (Mix Space v13+, x-api-key 认证) 或 v2 (legacy, Authorization 认证)。Auto 会按 endpoint 末段 (/api/v2 或 /api/v3) 推断。',
+      )
+      .addDropdown((d) => {
+        d.addOption('auto', 'Auto (detect from endpoint)')
+        d.addOption('v3', 'Mix Space v3 (v13+)')
+        d.addOption('v2', 'Mix Space v2 (legacy)')
+        d.setValue(activeProfile.apiVersion ?? 'auto')
+        d.onChange(async (v) => {
+          activeProfile.apiVersion = v === 'auto' ? undefined : (v as 'v2' | 'v3')
+          await this.plugin.saveSettings()
+          this.plugin.onProfileChange() // triggers api.updateProfile -> recompute apiVersion
+          this.display() // refresh to update endpoint/token copy below
+        })
+      })
+
     new Setting(containerEl)
       .setName('API Endpoint')
-      .setDesc('Your Mix Space API endpoint, ending in /api/v3 (e.g., https://your-domain.com/api/v3)')
+      .setDesc(
+        `Your Mix Space API endpoint, ending in /api/${effectiveVersion} (e.g., https://your-domain.com/api/${effectiveVersion})`,
+      )
       .addText((text) =>
         text
-          .setPlaceholder('https://your-domain.com/api/v3')
+          .setPlaceholder(`https://your-domain.com/api/${effectiveVersion}`)
           .setValue(activeProfile.apiEndpoint)
           .onChange(async (value) => {
             activeProfile.apiEndpoint = value
@@ -96,7 +119,11 @@ export class MixSpaceSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName('API Token')
-      .setDesc('Dashboard → 设定 → 账号与安全 → API Token (sent as the x-api-key header)')
+      .setDesc(
+        effectiveVersion === 'v2'
+          ? 'Dashboard → 设定 → 账号与安全 → API Token (sent as the Authorization header)'
+          : 'Dashboard → 设定 → 账号与安全 → API Token (sent as the x-api-key header)',
+      )
       .addText((text) => {
         text
           .setPlaceholder('Enter your token')

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import {
   getActiveProfile,
+  resolveApiVersion,
   DEFAULT_PROFILE,
   DEFAULT_SETTINGS,
   DEFAULT_AI_SETTINGS,
@@ -9,6 +10,40 @@ import {
   type MixSpaceSettings,
   type MixSpaceProfile,
 } from './types'
+
+describe('resolveApiVersion', () => {
+  it('should honor an explicit v2', () => {
+    expect(resolveApiVersion({ apiVersion: 'v2', apiEndpoint: '' })).toBe('v2')
+  })
+
+  it('should honor an explicit v3', () => {
+    expect(resolveApiVersion({ apiVersion: 'v3', apiEndpoint: '' })).toBe('v3')
+  })
+
+  it('should infer v2 from an /api/v2 endpoint', () => {
+    expect(resolveApiVersion({ apiEndpoint: 'https://x/api/v2' })).toBe('v2')
+  })
+
+  it('should infer v2 from an /api/v2/ endpoint (trailing slash)', () => {
+    expect(resolveApiVersion({ apiEndpoint: 'https://x/api/v2/' })).toBe('v2')
+  })
+
+  it('should infer v3 from an /api/v3 endpoint', () => {
+    expect(resolveApiVersion({ apiEndpoint: 'https://x/api/v3' })).toBe('v3')
+  })
+
+  it('should default to v3 when the endpoint has no version segment', () => {
+    expect(resolveApiVersion({ apiEndpoint: 'https://x' })).toBe('v3')
+  })
+
+  it('should default to v3 for an empty endpoint', () => {
+    expect(resolveApiVersion({ apiEndpoint: '' })).toBe('v3')
+  })
+
+  it('should let an explicit v3 override an /api/v2 endpoint', () => {
+    expect(resolveApiVersion({ apiVersion: 'v3', apiEndpoint: 'https://x/api/v2' })).toBe('v3')
+  })
+})
 
 describe('getActiveProfile', () => {
   it('should return the active profile when it exists', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,8 @@
+// Mix Space API version. v2 = legacy (Authorization header, bare responses,
+// camelCase fields). v3 = Mix Space v13+ (x-api-key header, { data } envelope,
+// snake_case fields).
+export type ApiVersion = 'v2' | 'v3'
+
 // Profile for different environments (production, development, etc.)
 export interface MixSpaceProfile {
   id: string
@@ -5,6 +10,20 @@ export interface MixSpaceProfile {
   apiEndpoint: string
   token: string
   siteUrl: string
+  apiVersion?: ApiVersion // optional; when absent, resolveApiVersion infers from endpoint / defaults to v3
+}
+
+// Resolve the effective API version for a profile.
+// Explicit apiVersion wins; otherwise infer from the endpoint's trailing segment;
+// fall back to the field-tested v3 when nothing matches.
+export function resolveApiVersion(
+  profile: Pick<MixSpaceProfile, 'apiVersion' | 'apiEndpoint'>,
+): ApiVersion {
+  if (profile.apiVersion === 'v2' || profile.apiVersion === 'v3') return profile.apiVersion
+  const base = (profile.apiEndpoint || '').replace(/\/$/, '')
+  if (/\/v2$/.test(base)) return 'v2'
+  if (/\/v3$/.test(base)) return 'v3'
+  return 'v3' // default safely to the field-tested v3
 }
 
 // AI Provider types
@@ -62,6 +81,7 @@ export const DEFAULT_PROFILE: MixSpaceProfile = {
   apiEndpoint: '',
   token: '',
   siteUrl: '',
+  apiVersion: 'v3',
 }
 
 export const DEFAULT_SETTINGS: MixSpaceSettings = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,26 +145,26 @@ export interface PostPayload {
   pin?: string | null
 }
 
-// Mix Space Note response
+// Mix Space Note response (v13: snake_case fields)
 export interface NoteResponse {
-  id: string // MongoDB _id
+  id: string
   nid: number
   title: string
-  created: string
-  modified: string | null
+  created_at: string
+  modified_at: string | null
   mood?: string
   weather?: string
-  topicId?: string
+  topic_id?: string
 }
 
-// Mix Space Post response
+// Mix Space Post response (v13: snake_case fields)
 export interface PostResponse {
   id: string
   title: string
   slug: string
-  created: string
-  modified: string | null
-  categoryId: string
+  created_at: string
+  modified_at: string | null
+  category_id: string
   category: Category
 }
 


### PR DESCRIPTION
## What & why

The plugin currently targets the Mix Space **v2** API. Mix Space **v13** ships a v3 API with breaking changes — a different auth header, a `{ data }` response envelope, a new error shape, `snake_case` fields, and a removed connection-test endpoint — so the plugin no longer works against current servers.

This PR adds **v3 support without dropping v2**. The effective version is resolved by a pure function (`resolveApiVersion`): an explicit per-profile `apiVersion` wins, otherwise it's inferred from the endpoint's trailing segment (`/api/v2` vs `/api/v3`), otherwise it defaults to v3. The parts that differ branch on the resolved version:

| Concern | v2 | v3 (v13+) |
| --- | --- | --- |
| Auth header | `Authorization: <token>` | `x-api-key: <token>` |
| Success envelope | bare resource | `{ data }` (unwrapped) |
| Error shape | `{ message }` | `{ error: { message } }` |
| Response fields | camelCase (normalized → snake_case) | snake_case |
| Connection test | `/master/check_logged` | owner-only `/snippets` |

A new **API Version** dropdown (Auto / v3 / v2) is added to settings, and the endpoint/token hints update to match the resolved version. Existing v2 users keep working; brand-new profiles default to v3 (current Mix Space), and legacy single-profile configs migrate to v2 to preserve current users' behavior.

## Notes for reviewers

- v2 list endpoints (`/categories`, `/topics`) return a `{ data }` envelope even though v2 single resources are bare, so `getCategories`/`getTopics` unwrap defensively for both shapes.
- v2 responses are normalized to the v3 `snake_case` shape at the API boundary, so downstream code (payload building, frontmatter write-back) stays version-agnostic.

## Testing

- 213 unit tests pass, including a dedicated v2-compatibility suite: auth header, bare-vs-enveloped responses, error parsing, field normalization, connection test, and the v2 list-envelope path.
- `tsc` type-check + build pass; `prettier --check` and `eslint` are clean.
- The **v3** path was verified end-to-end against a live Mix Space v13.3.1 instance (auth, create post, create note, delete).
- The **v2** path is unit-tested against documented v2 behavior but **not** verified against a live v2 server — extra eyes welcome there.
